### PR TITLE
Add hyperfine benchmark script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 Benchmarks for yk-based projects
 
 [Yk](https://github.com/ykjit/yk)
+
+
+## Running benchmarks
+
+Prerequisites:
+
+- [hyperfine](https://github.com/sharkdp/hyperfine#installation)
+
+```shell
+$ ./yklua/bench.sh ./build/yklua/src/lua # benchmarks with yklua 
+$ ./yklua/bench.sh /usr/bin/lua # benchmarks with lua
+```

--- a/yklua/bench.sh
+++ b/yklua/bench.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+set -eu
+
+lua=$1
+
+if [ ! -f "${lua}" ]; then
+    echo "Executable '$lua' not found" > /dev/stderr
+    exit 1
+fi
+
+hyperfine --warmup 1 --runs 10 "${lua} ./yklua/fannkuchredux.lua 3"
+hyperfine --warmup 1 --runs 10 "${lua} ./yklua/fasta.lua 10"
+hyperfine --warmup 1 --runs 10 "${lua} ./yklua/binary-trees.lua"


### PR DESCRIPTION
+ Add hyperfine benchmark script
+ Updated README with running instructions

Example:
```shell
$ ./yklua/bench.sh ./build/yklua/src/lua
Benchmark 1: ./build/yklua/src/lua ./yklua/fannkuchredux.lua 3
  Time (mean ± σ):      16.9 ms ±   3.6 ms    [User: 5.7 ms, System: 10.9 ms]
  Range (min … max):    13.8 ms …  49.8 ms    161 runs
 
Benchmark 1: ./build/yklua/src/lua ./yklua/fasta.lua 10
  Time (mean ± σ):      24.3 ms ±   2.5 ms    [User: 8.7 ms, System: 17.1 ms]
  Range (min … max):    20.2 ms …  33.9 ms    107 runs
 
Benchmark 1: ./build/yklua/src/lua ./yklua/binary-trees.lua
  Time (mean ± σ):      73.2 ms ±   6.8 ms    [User: 87.6 ms, System: 94.1 ms]
  Range (min … max):    65.8 ms … 105.9 ms    39 runs
```